### PR TITLE
Fix reference for ASP.NET MVC lib in Init project

### DIFF
--- a/Template/TemplateSrc/app/TemplateSrc.Init/TemplateSrc.Init.csproj
+++ b/Template/TemplateSrc/app/TemplateSrc.Init/TemplateSrc.Init.csproj
@@ -49,10 +49,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\lib\System.Web.Mvc.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
If you won't change reference and have installed mvc 4 betta, then mvc 4 is used and web project is still using MVC 3. in this case you get exception about not initialized nh session and its hard to resolve.

Some details https://groups.google.com/forum/?fromgroups#!topic/sharp-lite/DjJD4KiVQcg
