### PR TITLE
Added Queries to Entity Framework Provider

### DIFF
--- a/SharpLiteSrc/app/SharpLite.EntityFrameworkProvider/EntityFrameworkQuery.cs
+++ b/SharpLiteSrc/app/SharpLite.EntityFrameworkProvider/EntityFrameworkQuery.cs
@@ -1,0 +1,21 @@
+﻿namespace SharpLite.EntityFrameworkProvider
+{
+    using System;
+
+    public abstract class EntityFrameworkQuery
+    {
+        private readonly System.Data.Entity.DbContext _dbContext;
+
+        protected EntityFrameworkQuery(System.Data.Entity.DbContext dbContext) {
+            if (dbContext == null) throw new ArgumentNullException("dbContext may not be null");
+
+            this._dbContext = dbContext;
+        }
+
+        protected System.Data.Entity.DbContext DbContext {
+            get {
+                return this._dbContext;
+            }
+        }
+    }
+}

--- a/SharpLiteSrc/app/SharpLite.EntityFrameworkProvider/SharpLite.EntityFrameworkProvider.csproj
+++ b/SharpLiteSrc/app/SharpLite.EntityFrameworkProvider/SharpLite.EntityFrameworkProvider.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <Compile Include="DbContext.cs" />
     <Compile Include="EntityDuplicateChecker.cs" />
+    <Compile Include="EntityFrameworkQuery.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Repository.cs" />
   </ItemGroup>


### PR DESCRIPTION
Added Queries to Entity Framework Provider. This allows a user to create Enhanced Query Objects (meant to be read-only) that return View Models already shaped for display.'

This is similar to how S#arp Architecture does it with NHibernateQuery
